### PR TITLE
NOC-4594: add new gpg keys.

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -18,6 +18,7 @@ class datadog_agent::redhat(
         'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
         'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
         'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+        'https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public',
     ]
 
     if ($rpm_repo_gpgcheck != undef) {

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -17,6 +17,7 @@ class datadog_agent::suse(
     $current_key,
     'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
     'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+    'https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public',
   ]
 
   if ($rpm_repo_gpgcheck != undef) {

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -14,6 +14,7 @@ class datadog_agent::ubuntu(
   Optional[String] $apt_usr_share_keyring = '/usr/share/keyrings/datadog-archive-keyring.gpg',
   Optional[Hash[String, String]] $apt_default_keys = {
     'DATADOG_APT_KEY_CURRENT.public'           => 'https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public',
+    '5F1E256061D813B125E156E8E6266D4AC0962C7D' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public',
     'D75CEA17048B9ACBF186794B32637D44F14F620E' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public',
     'A2923DFF56EDA6E76E55E492D3A80E30382E94DE' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public',
   },

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -29,7 +29,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')\
           .with_repo_gpgcheck(false)
       end
@@ -77,7 +78,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')\
           .with_repo_gpgcheck(true)
       end
@@ -126,7 +128,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
           .with_repo_gpgcheck(true)
       end
@@ -178,7 +181,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
           .with_repo_gpgcheck(false)
       end
@@ -211,7 +215,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
           .with_repo_gpgcheck(true)
       end
@@ -242,7 +247,9 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
+
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
           .with_repo_gpgcheck(true)
       end
@@ -273,7 +280,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
           .with_repo_gpgcheck(true)
       end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -32,7 +32,8 @@ describe 'datadog_agent::suse' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
         # .with_repo_gpgcheck(true)
       end
@@ -51,7 +52,8 @@ describe 'datadog_agent::suse' do
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
         # .with_repo_gpgcheck(true)
       end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -5,6 +5,7 @@ shared_examples 'old debianoid' do
     is_expected.to contain_file('/usr/share/keyrings/datadog-archive-keyring.gpg')
     is_expected.to contain_file('/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg')
     is_expected.to contain_exec('ensure key DATADOG_APT_KEY_CURRENT.public is imported in APT keyring')
+    is_expected.to contain_exec('ensure key 5F1E256061D813B125E156E8E6266D4AC0962C7D is imported in APT keyring')
     is_expected.to contain_exec('ensure key D75CEA17048B9ACBF186794B32637D44F14F620E is imported in APT keyring')
     is_expected.to contain_exec('ensure key A2923DFF56EDA6E76E55E492D3A80E30382E94DE is imported in APT keyring')
   end
@@ -15,6 +16,7 @@ shared_examples 'new debianoid' do
     is_expected.to contain_file('/usr/share/keyrings/datadog-archive-keyring.gpg')
     is_expected.not_to contain_file('/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg')
     is_expected.to contain_exec('ensure key DATADOG_APT_KEY_CURRENT.public is imported in APT keyring')
+    is_expected.to contain_exec('ensure key 5F1E256061D813B125E156E8E6266D4AC0962C7D is imported in APT keyring')
     is_expected.to contain_exec('ensure key D75CEA17048B9ACBF186794B32637D44F14F620E is imported in APT keyring')
     is_expected.to contain_exec('ensure key A2923DFF56EDA6E76E55E492D3A80E30382E94DE is imported in APT keyring')
   end


### PR DESCRIPTION
Datadog is updating the GPG keys used for signing the agent packages, need to cherry-pick the upstream changes.
https://nasuni.atlassian.net/browse/NOC-4594

Bringing in this PR:
https://github.com/DataDog/puppet-datadog-agent/pull/782/files

**TESTING**
The puppet-base PR will be created once this PR is merged and the commit SHA is knows (for updating Puppetfile).
But a test pack against this branch has been done on tsupport1 to verify the additional gpg key is installed.

Run the `rpm` commands below on a support stack which has the updated datadog module and one which doesn't and see the additional key:
`gpg-pubkey-b01082d3-644161ac	gpg(Datadog, Inc. RPM key (2023-04-20) (RPM key) <package+rpmkey@datadoghq.com>)`

_(Not sure about the 2023-04-20 date in the key name, perhaps that is when it was created.)_

```
# run on tsupport1 where this updated datadog puppet module has been deployed
test tsupport1-us-east-2 > rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' $(rpm -q gpg-pubkey)
gpg-pubkey-c87f5b1a-593863f8	gpg(Amazon Linux <amazon-linux@amazon.com>)
gpg-pubkey-352c64e5-52ae6884	gpg(Fedora EPEL (7) <epel@fedoraproject.org>)
gpg-pubkey-9e61ef26-5cabbf8a	gpg(Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>)
gpg-pubkey-fd4bf915-5f573efe	gpg(Datadog, Inc. RPM key (2020-09-08) <package+rpmkey@datadoghq.com>)
gpg-pubkey-e09422b3-57744e9e	gpg(Datadog, Inc <package@datadoghq.com>)
gpg-pubkey-b01082d3-644161ac	gpg(Datadog, Inc. RPM key (2023-04-20) (RPM key) <package+rpmkey@datadoghq.com>)

# run the command below on dev or prod, where the change isn't deployed:
dev dsupport2-us-east-1 > rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' $(rpm -q gpg-pubkey)
gpg-pubkey-c87f5b1a-593863f8	gpg(Amazon Linux <amazon-linux@amazon.com>)
gpg-pubkey-352c64e5-52ae6884	gpg(Fedora EPEL (7) <epel@fedoraproject.org>)
gpg-pubkey-9e61ef26-5cabbf8a	gpg(Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>)
gpg-pubkey-fd4bf915-5f573efe	gpg(Datadog, Inc. RPM key (2020-09-08) <package+rpmkey@datadoghq.com>)
gpg-pubkey-e09422b3-57744e9e	gpg(Datadog, Inc <package@datadoghq.com>)
```
